### PR TITLE
[FEAT] API Documentation at /api/swagger-ui

### DIFF
--- a/dietstory-routing/dietstory-routing/settings.py
+++ b/dietstory-routing/dietstory-routing/settings.py
@@ -38,6 +38,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'registration.apps.RegistrationConfig',
+    'swagger-ui',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -62,7 +63,7 @@ ROOT_URLCONF = 'dietstory-routing.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ['templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/dietstory-routing/dietstory-routing/urls.py
+++ b/dietstory-routing/dietstory-routing/urls.py
@@ -19,4 +19,5 @@ from django.urls import path, include
 urlpatterns = [
     path('signup/', include('registration.urls')),
     path('admin/', admin.site.urls),
+    path('api/', include('swagger-ui.urls')),
 ]

--- a/dietstory-routing/registration/views.py
+++ b/dietstory-routing/registration/views.py
@@ -12,6 +12,18 @@ class SignupView(views.APIView):
     permission_classes = (permissions.AllowAny,)
 
     def get(self, request, *args, **kwargs):
+        """
+        summary: Get Signup description
+        description: Informs required parameters for POST request
+        tags:
+            - SignupView
+        responses:
+            200:
+                content:
+                    application/json:
+                        schema:
+                            type: string
+        """
         return HttpResponse("Welcome to signup page. Please enter username, email, password, and birthday.", status=200)
 
     # @method_decorator(sensitive_post_parameters('password'))

--- a/dietstory-routing/swagger-ui/swagger_schema.py
+++ b/dietstory-routing/swagger-ui/swagger_schema.py
@@ -1,0 +1,42 @@
+from rest_framework.schemas.openapi import SchemaGenerator
+from urllib.parse import urljoin
+import yaml
+
+class SwaggerSchemaGenerator(SchemaGenerator):
+    # Override get_paths functionality
+    def get_paths(self, request=None):
+        result = {}
+
+        paths, view_endpoints = self._get_paths_and_endpoints(request)
+
+        # Only generate the path prefix for paths that will be included
+        if not paths:
+            return None
+
+        for path, method, view in view_endpoints:
+            if not self.has_view_permissions(path, method, view):
+                continue
+            operation = view.schema.get_operation(path, method)
+            # Normalise path for any provided mount url.
+            if path.startswith('/'):
+                path = path[1:]
+            path = urljoin(self.url or '/', path)
+            result.setdefault(path, {})
+            doc_operation = self.__extract_yaml__(view, method)
+            if doc_operation:
+                operation.update(doc_operation)
+            result[path][method.lower()] = operation
+        return result
+
+    def __extract_yaml__(self, view, method):
+        yaml_doc = None
+        if view and method:
+            # Get corresponding function
+            view_func = getattr(view, method.lower())
+            if view_func:
+                try:
+                    yaml_doc = yaml.safe_load(view_func.__doc__)
+                except:
+                    yaml_doc = None    
+
+        return yaml_doc

--- a/dietstory-routing/swagger-ui/templates/swagger-ui.html
+++ b/dietstory-routing/swagger-ui/templates/swagger-ui.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Swagger</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script>
+    const ui = SwaggerUIBundle({
+        url: "{% url schema_url %}",
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout"
+      })
+    </script>
+  </body>
+</html>

--- a/dietstory-routing/swagger-ui/urls.py
+++ b/dietstory-routing/swagger-ui/urls.py
@@ -1,0 +1,16 @@
+from django.urls import include, path
+from django.views.generic import TemplateView
+from rest_framework.schemas import get_schema_view
+from .swagger_schema import SwaggerSchemaGenerator
+
+urlpatterns = [
+	path('openapi', get_schema_view(
+        title="Dietstory API",
+        description="API Documentation for Dietstory service.",
+        generator_class=SwaggerSchemaGenerator
+    ), name='openapi-schema'),
+    path('swagger-ui/', TemplateView.as_view(
+        template_name='swagger-ui.html',
+        extra_context={'schema_url':'openapi-schema'}
+    ), name='swagger-ui'),
+]


### PR DESCRIPTION
Added new url `/api/swagger-ui` for api documentation
Added new url `/api/openapi` for non-styled api information
- Auto generates doc if YAML styled comments are made in view function calls.