### PR TITLE
[FIX] - Empty filename issue. Normalized versionid request parameter.

### DIFF
--- a/dietstory-routing/game_asset_manager/validate_forms.py
+++ b/dietstory-routing/game_asset_manager/validate_forms.py
@@ -33,7 +33,7 @@ class CharFieldArrayValidator(BaseValidator):
     message = "CharFieldArray must be of the form: {0}{1}{0}{1}...".format('<CHAR_FIELD>', '<DELIMETER>')
 
 
-
+# Base form with versionid applied
 class GameMetadataForm(forms.Form):
     versionid = forms.CharField(max_length=16, required=False, validators=[VersionIdValidator(True)])
 
@@ -55,12 +55,10 @@ class RequestGameAssetForm(GameMetadataForm):
     def clean(self):
         cleaned_data = super().clean()
         filenames_string = cleaned_data.get('filenames')
-        cleaned_data['filenames'] = filenames_string.split(',')
+        cleaned_data['filenames'] = filenames_string.split(',') if filenames_string else []
 
 
-class SubmitGameVersionForm(forms.Form):
-	major_ver = forms.IntegerField(validators=[MinValueValidator(0)])
-	minor_ver = forms.IntegerField(validators=[MinValueValidator(0)])
+class SubmitGameVersionForm(GameMetadataForm):
 	live_by = forms.DateTimeField(required=False)
 
 

--- a/dietstory-routing/game_asset_manager/views.py
+++ b/dietstory-routing/game_asset_manager/views.py
@@ -192,8 +192,7 @@ class GameVersionView(views.APIView):
         if game_version_form.is_valid():
 
             try:
-                major_ver = game_version_form.cleaned_data.get('major_ver')
-                minor_ver = game_version_form.cleaned_data.get('minor_ver')
+                major_ver, minor_ver = game_version_form.get_version_values();
                 live_by = game_version_form.cleaned_data.get('live_by')
 
                 game_version = GameVersions(major_ver=major_ver, minor_ver=minor_ver, live_by=live_by)


### PR DESCRIPTION
- Ensure empty list if provided list f filenames is empty `/game-files/download`
- Updated `SubmitGameVersionForm` to use `GameMetadataForm` request parameters.